### PR TITLE
fix(app): infinite recursion failed to fetch available oprec job

### DIFF
--- a/js/homepage.js
+++ b/js/homepage.js
@@ -466,21 +466,20 @@ function formatJobType(type) {
 
 // Update the formatRealDate function
 function formatRealDate(dateInput) {
-    // Use the universal date formatter
-    if (window.formatRealDate) {
-        return window.formatRealDate(dateInput);
-    }
-    
-    // Fallback if the universal formatter isn't loaded
     if (!dateInput) return 'Recently posted';
     
     try {
         let date;
         
+        // Handle Jackson array format [YYYY, MM, DD, HH, MM, SS]
         if (Array.isArray(dateInput) && dateInput.length >= 6) {
             date = new Date(dateInput[0], dateInput[1] - 1, dateInput[2], dateInput[3] || 0, dateInput[4] || 0, dateInput[5] || 0);
-        } else {
+        } else if (typeof dateInput === 'string') {
             date = new Date(dateInput);
+        } else if (dateInput instanceof Date) {
+            date = dateInput;
+        } else {
+            return 'Recently posted';
         }
         
         if (isNaN(date.getTime())) {


### PR DESCRIPTION
# 🐛 Fix: Infinite Recursion in Homepage Job Loading

## 📋 Summary
This pull request fixes a critical infinite recursion bug that was preventing the Open Recruitment jobs from loading on the homepage. The issue was caused by the `formatRealDate` function calling itself recursively, leading to a "Maximum call stack size exceeded" error.

## 🔍 Problem Description
- Homepage was failing to load Open Recruitment jobs
- Console showed "Maximum call stack size exceeded" error
- The error was traced to the `formatRealDate` function in `js/homepage.js` at line 471
- Function was recursively calling `window.formatRealDate` which pointed to itself

## 🛠️ Changes Made

### Fixed in `js/homepage.js`:
- **Removed infinite recursion**: Eliminated the problematic check for `window.formatRealDate` that was causing the function to call itself infinitely
- **Improved date handling**: Enhanced the function to properly handle different date input formats:
  - Jackson array format `[YYYY, MM, DD, HH, MM, SS]`
  - ISO string format
  - Date objects
- **Added better error handling**: More robust validation and fallback mechanisms
- **Streamlined logic**: Simplified the date formatting logic to prevent future recursion issues

### Key Code Changes:
```diff
- // Use the universal date formatter
- if (window.formatRealDate) {
-     return window.formatRealDate(dateInput);
- }
- 
- // Fallback if the universal formatter isn't loaded
+ // Direct implementation without recursion
  if (!dateInput) return 'Recently posted';